### PR TITLE
ovirtbmc: Fix vm status check condition

### DIFF
--- a/ovirtbmc/ovirtbmc.py
+++ b/ovirtbmc/ovirtbmc.py
@@ -106,7 +106,9 @@ class OvirtBmc(Bmc):
             self.cached_status = vm.status
 
         vm_is_up = self.cached_status == types.VmStatus.UP
-        vm_is_powering_up = self.cached_status == (types.VmStatus.POWERING_UP or types.VmStatus.REBOOTING)
+        vm_is_powering_up = (
+            self.cached_status == types.VmStatus.POWERING_UP or self.cached_status == types.VmStatus.REBOOTING
+        )
 
         return vm_is_up or vm_is_powering_up
 


### PR DESCRIPTION
`(x or y)` in Python evaluates to first non-falsey value, so we're
effectively only checking if a VM is in 'POWERING_UP' status.

Signed-off-by: Marcin Sobczyk <msobczyk@redhat.com>
