### PR TITLE
ovirtbmc: Support managing multiple VMs

### DIFF
--- a/ovirtbmc/ovirtbmc.py
+++ b/ovirtbmc/ovirtbmc.py
@@ -48,7 +48,7 @@ class OvirtBmc(Bmc):
         self.target_status = None
         try:
             self.vm_id, self.vm_name = self._find_vm(vm)
-            self.log(f'Managing vm {self.vm_name} ({self.vm_id})')
+            self.log(f'Managing vm {self.vm_name} ({self.vm_id}) on port {port}')
         except Exception as e:
             self.log(f'Exception finding vm "{vm}": {e}')
             sys.exit(1)


### PR DESCRIPTION
This PR adds support for managing multiple VMs on separate ports.

The implementation is based on 'fork' system call which spawns one child
process per VM. The parent process exits when all the child processes
are finished.

Signed-off-by: Marcin Sobczyk <msobczyk@redhat.com>
