### PR TITLE
ovirtbmc: Fix cache handling

### DIFF
--- a/ovirtbmc/ovirtbmc.py
+++ b/ovirtbmc/ovirtbmc.py
@@ -99,7 +99,7 @@ class OvirtBmc(Bmc):
 
     def _vm_up(self):
         no_cached_data = self.cached_status is None
-        vm_changing_state = self.cached_status != self.target_status
+        vm_changing_state = self.target_status is not None and self.cached_status != self.target_status
 
         if no_cached_data or vm_changing_state or self.cache_disabled:
             vm = self.vms_service.service(self.vm_id).get()


### PR DESCRIPTION
When we never use power on/off commands, 'target_status' is 'None'
and the VM stays in 'vm_changing_state' forever. Let's add a condition
to see if we ever used the power on/off commands.

Signed-off-by: Marcin Sobczyk <msobczyk@redhat.com>
